### PR TITLE
Add dark admin UI and routing API

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>NodeBroker UI</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <h1>NodeBroker Admin</h1>
+  <section id="routes-section">
+    <h2>Routes</h2>
+    <table id="routes-table">
+      <thead>
+        <tr><th>Domain</th><th>Target</th><th>Actions</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <h3>Add Route</h3>
+    <form id="add-route-form">
+      <input type="text" id="domain" placeholder="Domain" required>
+      <input type="text" id="target" placeholder="Target URL" required>
+      <button type="submit">Add</button>
+    </form>
+  </section>
+  <section id="certs-section">
+    <h2>Certificates</h2>
+    <p>Let's Encrypt integration <em>coming soon</em>.</p>
+  </section>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/public/main.js
+++ b/public/main.js
@@ -1,0 +1,36 @@
+async function loadRoutes() {
+  const res = await fetch('/api/routes');
+  const routes = await res.json();
+  const tbody = document.querySelector('#routes-table tbody');
+  tbody.innerHTML = '';
+  routes.forEach(r => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${r.domain}</td><td>${r.target}</td>` +
+      `<td><button data-domain="${r.domain}" class="delete-btn">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('add-route-form').addEventListener('submit', async e => {
+  e.preventDefault();
+  const domain = document.getElementById('domain').value.trim();
+  const target = document.getElementById('target').value.trim();
+  if (!domain || !target) return;
+  await fetch('/api/routes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ domain, target })
+  });
+  e.target.reset();
+  loadRoutes();
+});
+
+document.querySelector('#routes-table tbody').addEventListener('click', async e => {
+  if (e.target.classList.contains('delete-btn')) {
+    const domain = e.target.dataset.domain;
+    await fetch('/api/routes/' + encodeURIComponent(domain), { method: 'DELETE' });
+    loadRoutes();
+  }
+});
+
+loadRoutes();

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,30 @@
+body {
+  background-color: #121212;
+  color: #eee;
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 1rem;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-bottom: 1rem;
+}
+
+th, td {
+  border: 1px solid #444;
+  padding: 0.5rem;
+}
+
+input, button {
+  margin-right: 0.5rem;
+  padding: 0.5rem;
+  background: #222;
+  color: #eee;
+  border: 1px solid #555;
+}
+
+button {
+  cursor: pointer;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,9 @@ const path = require('path');
 const app = express();
 const proxy = httpProxy.createProxyServer({});
 
+app.use(express.json());
+app.use('/ui', express.static(path.join(__dirname, '../public')));
+
 // Simple in-memory routing table
 const routes = [
   // Example route: { domain: 'example.com', target: 'http://localhost:3000' }
@@ -16,6 +19,31 @@ function loadRoutes() {
   // Placeholder for loading from SQLite in future
   return routes;
 }
+
+// API endpoints for managing routes
+app.get('/api/routes', (req, res) => {
+  res.json(loadRoutes());
+});
+
+app.post('/api/routes', (req, res) => {
+  const { domain, target } = req.body;
+  if (!domain || !target) {
+    return res.status(400).json({ error: 'Missing domain or target' });
+  }
+  // TODO: persist routes to SQLite
+  routes.push({ domain, target });
+  res.status(201).json({ status: 'created' });
+});
+
+app.delete('/api/routes/:domain', (req, res) => {
+  const idx = routes.findIndex(r => r.domain === req.params.domain);
+  if (idx === -1) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+  // TODO: persist deletion to SQLite
+  routes.splice(idx, 1);
+  res.json({ status: 'deleted' });
+});
 
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });


### PR DESCRIPTION
## Summary
- expose REST endpoints to manage routes
- serve new admin UI under `/ui`
- add simple HTML/JS frontend with dark theme

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870eb7ea6b483339d393ccd0cb0d715