### PR TITLE
Add SQLite persistence for routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ NodeBroker is a lightweight reverse proxy with a simple web interface. It routes
 - Express-based server
 - HTTP proxy using `http-proxy`
 - Health check endpoint at `/health`
-- Configuration placeholder for SQLite-backed routing (work in progress)
+- Routes persisted in a SQLite database
 
 ## Development
 

--- a/src/db.js
+++ b/src/db.js
@@ -1,0 +1,47 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+const dbFile = process.env.DB_FILE || path.join(__dirname, '../nodebroker.db');
+const db = new sqlite3.Database(dbFile);
+
+function init() {
+  return new Promise((resolve, reject) => {
+    db.run(
+      `CREATE TABLE IF NOT EXISTS routes (
+        domain TEXT PRIMARY KEY,
+        target TEXT NOT NULL
+      )`,
+      err => (err ? reject(err) : resolve())
+    );
+  });
+}
+
+function getRoutes() {
+  return new Promise((resolve, reject) => {
+    db.all('SELECT domain, target FROM routes', (err, rows) => {
+      if (err) reject(err);
+      else resolve(rows);
+    });
+  });
+}
+
+function addRoute(domain, target) {
+  return new Promise((resolve, reject) => {
+    db.run(
+      'INSERT OR REPLACE INTO routes(domain, target) VALUES(?, ?)',
+      [domain, target],
+      err => (err ? reject(err) : resolve())
+    );
+  });
+}
+
+function deleteRoute(domain) {
+  return new Promise((resolve, reject) => {
+    db.run('DELETE FROM routes WHERE domain = ?', [domain], function (err) {
+      if (err) reject(err);
+      else resolve(this.changes > 0);
+    });
+  });
+}
+
+module.exports = { init, getRoutes, addRoute, deleteRoute };

--- a/test/routes.test.js
+++ b/test/routes.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+let app;
+
+describe('Routes API', () => {
+  beforeAll(() => {
+    process.env.DB_FILE = ':memory:';
+    app = require('../src/index');
+  });
+
+  test('create and list routes', async () => {
+    const payload = { domain: 'test.local', target: 'http://localhost:3001' };
+    const res = await request(app).post('/api/routes').send(payload);
+    expect(res.statusCode).toBe(201);
+    const list = await request(app).get('/api/routes');
+    expect(list.body).toEqual([payload]);
+  });
+
+  test('delete route', async () => {
+    const domain = 'remove.local';
+    await request(app)
+      .post('/api/routes')
+      .send({ domain, target: 'http://localhost:3002' });
+    const del = await request(app).delete('/api/routes/' + domain);
+    expect(del.statusCode).toBe(200);
+    const list = await request(app).get('/api/routes');
+    expect(list.body.find(r => r.domain === domain)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- implement a small SQLite helper
- persist routes in SQLite database instead of memory
- extend API endpoints to use the database
- update readme to mention SQLite persistence
- add tests for the routes API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870ef8a6244833389a27d02eb0aa9da