### PR TITLE
Implement ping-based HA routes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "dotenv": "^17.2.0",
         "express": "^5.1.0",
         "http-proxy": "^1.18.1",
+        "ping": "^0.4.4",
         "selfsigned": "^2.4.1",
         "sqlite3": "^5.1.7"
       },
@@ -5316,6 +5317,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/ping": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/ping/-/ping-0.4.4.tgz",
+      "integrity": "sha512-56ZMC0j7SCsMMLdOoUg12VZCfj/+ZO+yfOSjaNCRrmZZr6GLbN2X/Ui56T15dI8NhiHckaw5X2pvyfAomanwqQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/pirates": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dotenv": "^17.2.0",
     "express": "^5.1.0",
     "http-proxy": "^1.18.1",
+    "ping": "^0.4.4",
     "selfsigned": "^2.4.1",
     "sqlite3": "^5.1.7"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ require('dotenv').config();
 const express = require('express');
 const httpProxy = require('http-proxy');
 const path = require('path');
+const ping = require('ping');
 const db = require('./db');
 const certs = require('./certs');
 
@@ -11,13 +12,19 @@ const proxy = httpProxy.createProxyServer({});
 app.use(express.json());
 app.use('/ui', express.static(path.join(__dirname, '../public')));
 
-db.init().catch(err => {
+const initPromise = db.init().catch(err => {
   console.error('Failed to initialize database', err);
   process.exit(1);
 });
 
 async function loadRoutes() {
+  await initPromise;
   return db.getRoutes();
+}
+
+async function loadHaRoutes() {
+  await initPromise;
+  return db.getHaRoutes();
 }
 
 // API endpoints for managing routes
@@ -78,6 +85,43 @@ app.delete('/api/routes/:domain', async (req, res, next) => {
   }
 });
 
+// API endpoints for managing HA routes
+app.get('/api/ha/routes', async (req, res, next) => {
+  try {
+    const list = await loadHaRoutes();
+    res.json(list);
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.post('/api/ha/routes', async (req, res, next) => {
+  const { domain, primary, backup } = req.body;
+  if (!domain || !primary || !backup) {
+    return res.status(400).json({ error: 'Missing domain or targets' });
+  }
+  try {
+    await initPromise;
+    await db.addHaRoute(domain, primary, backup);
+    res.status(201).json({ status: 'created' });
+  } catch (err) {
+    next(err);
+  }
+});
+
+app.delete('/api/ha/routes/:domain', async (req, res, next) => {
+  try {
+    await initPromise;
+    const deleted = await db.deleteHaRoute(req.params.domain);
+    if (!deleted) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    res.json({ status: 'deleted' });
+  } catch (err) {
+    next(err);
+  }
+});
+
 app.get('/health', (req, res) => {
   res.json({ status: 'ok' });
 });
@@ -89,6 +133,26 @@ app.use(async (req, res, next) => {
     const route = routes.find(r => r.domain === host);
     if (route) {
       proxy.web(req, res, { target: route.target }, err => {
+        console.error('Proxy error:', err);
+        res.status(502).send('Bad gateway');
+      });
+      return;
+    }
+
+    const haRoutes = await loadHaRoutes();
+    const haRoute = haRoutes.find(r => r.domain === host);
+    if (haRoute) {
+      let target = haRoute.primary;
+      try {
+        const hostToPing = new URL(haRoute.primary).hostname;
+        const result = await ping.promise.probe(hostToPing);
+        if (!result.alive) {
+          target = haRoute.backup;
+        }
+      } catch (e) {
+        target = haRoute.backup;
+      }
+      proxy.web(req, res, { target }, err => {
         console.error('Proxy error:', err);
         res.status(502).send('Bad gateway');
       });

--- a/test/haRoutes.test.js
+++ b/test/haRoutes.test.js
@@ -1,0 +1,28 @@
+const request = require('supertest');
+let app;
+
+describe('HA Routes API', () => {
+  beforeAll(() => {
+    process.env.DB_FILE = ':memory:';
+    app = require('../src/index');
+  });
+
+  test('create and list ha routes', async () => {
+    const payload = { domain: 'ha.local', primary: 'http://localhost:3001', backup: 'http://localhost:3002' };
+    const res = await request(app).post('/api/ha/routes').send(payload);
+    expect(res.statusCode).toBe(201);
+    const list = await request(app).get('/api/ha/routes');
+    expect(list.body).toEqual([payload]);
+  });
+
+  test('delete ha route', async () => {
+    const domain = 'remove.ha';
+    await request(app)
+      .post('/api/ha/routes')
+      .send({ domain, primary: 'http://localhost:3001', backup: 'http://localhost:3002' });
+    const del = await request(app).delete('/api/ha/routes/' + domain);
+    expect(del.statusCode).toBe(200);
+    const list = await request(app).get('/api/ha/routes');
+    expect(list.body.find(r => r.domain === domain)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- add `ping` dependency
- extend database to store HA routes
- add API endpoints to manage HA routes
- proxy requests with ping-based failover
- test HA routes behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6870f6ef1c648333972494e4f2bb6539