### PR TITLE
Add web UI for LetsEncrypt and HA routes

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,10 +30,33 @@
       </thead>
       <tbody></tbody>
     </table>
-    <h3>Issue Certificate</h3>
+    <h3>Issue Self-Signed Certificate</h3>
     <form id="add-cert-form">
       <input type="text" id="cert-domain" placeholder="Domain" required>
       <button type="submit">Issue</button>
+    </form>
+    <h3>Issue Let's Encrypt Certificate</h3>
+    <form id="add-le-form">
+      <input type="text" id="le-domain" placeholder="Domain" required>
+      <input type="email" id="le-email" placeholder="Email" required>
+      <button type="submit">Issue</button>
+    </form>
+  </section>
+
+  <section id="ha-routes-section">
+    <h2>HA Routes</h2>
+    <table id="ha-routes-table">
+      <thead>
+        <tr><th>Domain</th><th>Primary</th><th>Backup</th><th>Actions</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+    <h3>Add HA Route</h3>
+    <form id="add-ha-form">
+      <input type="text" id="ha-domain" placeholder="Domain" required>
+      <input type="text" id="ha-primary" placeholder="Primary URL" required>
+      <input type="text" id="ha-backup" placeholder="Backup URL" required>
+      <button type="submit">Add</button>
     </form>
   </section>
   <script src="main.js"></script>

--- a/public/main.js
+++ b/public/main.js
@@ -61,3 +61,55 @@ document.getElementById('add-cert-form').addEventListener('submit', async e => {
 });
 
 loadCerts();
+
+async function loadHaRoutes() {
+  const res = await fetch('/api/ha/routes');
+  const routes = await res.json();
+  const tbody = document.querySelector('#ha-routes-table tbody');
+  tbody.innerHTML = '';
+  routes.forEach(r => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${r.domain}</td><td>${r.primary}</td><td>${r.backup}</td>` +
+      `<td><button data-domain="${r.domain}" class="delete-ha-btn">Delete</button></td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+document.getElementById('add-ha-form').addEventListener('submit', async e => {
+  e.preventDefault();
+  const domain = document.getElementById('ha-domain').value.trim();
+  const primary = document.getElementById('ha-primary').value.trim();
+  const backup = document.getElementById('ha-backup').value.trim();
+  if (!domain || !primary || !backup) return;
+  await fetch('/api/ha/routes', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ domain, primary, backup })
+  });
+  e.target.reset();
+  loadHaRoutes();
+});
+
+document.querySelector('#ha-routes-table tbody').addEventListener('click', async e => {
+  if (e.target.classList.contains('delete-ha-btn')) {
+    const domain = e.target.dataset.domain;
+    await fetch('/api/ha/routes/' + encodeURIComponent(domain), { method: 'DELETE' });
+    loadHaRoutes();
+  }
+});
+
+loadHaRoutes();
+
+document.getElementById('add-le-form').addEventListener('submit', async e => {
+  e.preventDefault();
+  const domain = document.getElementById('le-domain').value.trim();
+  const email = document.getElementById('le-email').value.trim();
+  if (!domain || !email) return;
+  await fetch('/api/letsencrypt', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ domain, email })
+  });
+  e.target.reset();
+  loadCerts();
+});


### PR DESCRIPTION
## Summary
- expose Let's Encrypt issuance form
- add management section for HA routes
- implement JS logic for new forms and tables

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871032e065c833387ddf4583dca65f1